### PR TITLE
fix: allow json-database 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
     "ovos-plugin-manager>=2.1.0,<3.0.0",
-    "json_database~=0.7"
+    "json_database>=0.7,<2.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
`json_database~=0.7` (=`>=0.7,<1.0`) excludes json_database 1.x (`1.0.2a1`, which dropped the duplicate `hivemind-json-db-plugin` entry point). Widen to `>=0.7,<2.0.0` — this is the last consumer holding json_database below 1.x once the package is added to ovos-releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)